### PR TITLE
fix daily rate wizard input

### DIFF
--- a/src/hooks/useCreateRealmWizard.ts
+++ b/src/hooks/useCreateRealmWizard.ts
@@ -72,7 +72,7 @@ export default () => {
             : realm.allowedCollections.map(x => x.value).filter(Boolean),
         config: {
           token: realm.tokenAddress,
-          dailyRate: realm.claimableTokenRate,
+          dailyRate: BigNumber.from(realm.claimableTokenRate).mul(decimals),
           constraints: {
             minInfusionAmount: BigNumber.from(
               realm.minTokenInfusionAmount || 0


### PR DESCRIPTION
i left out the decimals part in the UI when i switched over to per-realm daily rate