### PR TITLE
fix image metadata for makersplace nfts

### DIFF
--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -21,9 +21,21 @@ export const fetchIpfsJson = memoize(
 );
 
 // if a uri is an ipfs-ish uri, convert it to a https featchable able
-export const ensureHttpsUri = (uri: string): string => {
-  const hash = extractIpfsHash(uri);
-  return hash ? ipfsHashAsHttp(hash) : uri;
+export const rewriteIpfsUri = (uri: string | undefined): string | undefined => {
+  if (uri == null) return undefined;
+
+  const isIpfsIo = /^https:\/\/ipfs.io\/ipfs/.test(uri);
+  const isHttps = /^https:\/\//.test(uri);
+
+  // if its not already https, or if its ipfs's public (slow/throttled) gateway,
+  // then rewrite
+  if (!isHttps || isIpfsIo) {
+    const hash = extractIpfsHash(uri);
+    return hash ? ipfsHashAsHttp(hash) : uri;
+  }
+
+  // else no-op
+  return uri;
 };
 
 // fetchable https uri from an ipfs hash


### PR DESCRIPTION
* modify ipfs / metadata logic to ensure video files from makers place render properly

broken:
https://app.hypervibes.xyz/mainnet/realms/4/nfts

fixed:
https://deploy-preview-19--hypervibes-app.netlify.app/mainnet/realms/4/nfts